### PR TITLE
Adjusting classifier to return classification ID instead of classification text

### DIFF
--- a/preppingScripts/modelBuilder.py
+++ b/preppingScripts/modelBuilder.py
@@ -34,7 +34,7 @@ vectorizer = CountVectorizer(min_df=10, ngram_range=(1,3), stop_words='english')
 X = vectorizer.fit_transform(df['CLMANT_TXT'])
 
 #This are the labels we are trying to predict
-y = np.array(df['newClass'])
+y = np.array(df['CNTNTN_CLSFCN_ID'])
 
 # Split into a training and testing set.
 X_train, X_test, y_train, y_test, i_train, i_test = train_test_split(X, y, df.index, test_size=0.7, random_state=42)


### PR DESCRIPTION
Hi Bennett,

Here's my PR for the code change to get the classifier to go back to returning the classification ID instead of the classification text. It's just a one line change, so it's super simple. One caveat/question, though. When I finished re-building the model using the process outlined in the readme (e.g. cleaning input CSV -> building the model using the cleaned CSV), I got scores in the 80-82% range instead of the 90-92% range. This was using the Large_Training.csv file on your Dropbox (updated 4/11). Has this file been updated since then? If so, can you please push the new one? If not, any idea for the drop?

Thanks,
Chris